### PR TITLE
Update jQuery to 3.5.1

### DIFF
--- a/DocuSign.MyHR/DocuSign.MyHR/ClientApp/package-lock.json
+++ b/DocuSign.MyHR/DocuSign.MyHR/ClientApp/package-lock.json
@@ -8533,9 +8533,9 @@
       }
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "js-base64": {
       "version": "2.5.2",

--- a/DocuSign.MyHR/DocuSign.MyHR/ClientApp/package.json
+++ b/DocuSign.MyHR/DocuSign.MyHR/ClientApp/package.json
@@ -32,7 +32,7 @@
     "core-js": "^2.6.5",
     "date-fns": "^2.14.0",
     "i18n-iso-countries": "^5.4.0",
-    "jquery": "3.5.0",
+    "jquery": "3.5.1",
     "oidc-client": "^1.9.0",
     "popper.js": "^1.14.3",
     "rxjs": "^6.4.0",


### PR DESCRIPTION
Updating jQuery to 3.5.1 due to breaking change in jQuery 3.5.0: https://github.com/jquery/jquery/issues/4665